### PR TITLE
🎉 added initial working prototype

### DIFF
--- a/src/modules/elevation.ts
+++ b/src/modules/elevation.ts
@@ -1,0 +1,22 @@
+import { basename } from "https://deno.land/std@0.103.0/path/mod.ts";
+
+export async function isAdmin() {
+  const testCMD = Deno.run({
+    cmd: [`net`, `session`],
+    stdout: "null",
+    stderr: "null",
+  });
+  return (await testCMD.status()).code == 0;
+}
+
+export async function elevate() {
+  if (await isAdmin()) return;
+  Deno.run({
+    cmd: [
+      `Powershell`,
+      `-Command`,
+      `Start "${Deno.execPath()}"${Deno.args[0] ? ` "${Deno.args.join(' ')}"` : ''} -Verb Runas`,
+    ],
+  });
+  Deno.exit(0);
+}

--- a/src/modules/service.ts
+++ b/src/modules/service.ts
@@ -1,0 +1,15 @@
+export async function isRunning(name: string): Promise<boolean> {
+    const p = Deno.run({
+        cmd: [
+            `sc`,
+            `query`,
+            `WireGuardTunnel$${name}`
+        ],
+        stdout: "piped",
+        stderr: "piped",
+    });
+    const { code } = await p.status();
+    const rawOutput = await p.output();
+
+    return (code == 0 && new TextDecoder().decode(rawOutput).includes(`RUNNING`))
+}

--- a/src/modules/ux.ts
+++ b/src/modules/ux.ts
@@ -1,0 +1,20 @@
+import { readLines } from "https://deno.land/std@0.103.0/io/mod.ts";
+import { config } from "./wireguard.ts";
+
+export async function promt(msg?: string) {
+  msg && console.log(msg);
+  // Listen to stdin input, once a new line is entered return
+  for await (const line of readLines(Deno.stdin)) {
+    return line;
+  }
+}
+
+export function printConfigs(configs: Array<config>) {
+    configs.forEach((config, index) => {
+		console.log(`${index + 1}: ${config.name} (${config.status ? `running` : `stopped`})`)
+	})    
+}
+
+export function Sleep(milliseconds: number) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}

--- a/src/modules/wireguard.ts
+++ b/src/modules/wireguard.ts
@@ -1,0 +1,82 @@
+import { dirname, join, extname, parse } from "https://deno.land/std@0.103.0/path/mod.ts";
+import { isRunning } from "./service.ts";
+
+export async function installPath(): Promise<string> {
+    const p = Deno.run({
+        cmd: [
+            `where`,
+            `wireguard`
+        ],
+        stdout: "piped",
+        stderr: "piped",
+    });
+    const { code } = await p.status();
+    const rawOutput = await p.output();
+
+    if (code != 0) throw new Error(`WireGuard has not been added to $PATH and thus can not be found. Please add WireGuard to $PATH!`);
+
+    return new TextDecoder().decode(rawOutput)
+}
+
+async function configPath(): Promise<string> {
+    return join(dirname(await installPath()), `Data\\Configurations`)
+}
+
+export interface config {
+    name: string,
+    path: string,
+    status: boolean
+}
+
+export async function getConfigs() {
+    const path = await configPath()
+    const configs = new Array<config>()
+    for await (const dirEntry of Deno.readDir(path)) {
+        if (dirEntry.isFile && extname(dirEntry.name) == `.dpapi` ) {
+            const parsedName = parse(parse(dirEntry.name).name).name;
+            configs.push({name: parsedName, path: join(path, dirEntry.name), status: await isRunning(parsedName)})
+        }
+    }
+    return configs
+}
+
+export async function toggleConfig(config: config) {
+    let cmd = [
+        `wireguard`,
+        `/installtunnelservice`,
+        `${config.path}`,
+    ]
+    if (config.status == true) {
+        cmd = [
+            `wireguard`,
+            `/uninstalltunnelservice`,
+            `${config.name}`,
+        ]
+    }
+
+    const p = Deno.run({
+        cmd: cmd,
+        stdout: "piped",
+        stderr: "piped",
+    });
+
+	
+	const { code } = await p.status();
+	
+	const rawOutput = await p.output();
+	const rawError = await p.stderrOutput();
+	
+	if (code === 0) {
+		await Deno.stdout.write(rawOutput);
+	} else {
+		const errorString = new TextDecoder().decode(rawError);
+		console.log(errorString);
+	}    
+}
+
+export async function getConfigByName(name: string) {
+    const configs = await getConfigs()
+    return configs.filter(config => {
+        return config.name === name
+    })
+}

--- a/src/wg-quick.ts
+++ b/src/wg-quick.ts
@@ -1,0 +1,44 @@
+import { elevate } from "./modules/elevation.ts";
+import { getConfigs, toggleConfig, getConfigByName } from "./modules/wireguard.ts";
+import { promt, printConfigs, Sleep } from "./modules/ux.ts";
+
+const isValidInput = Deno.args.length == 2 && (Deno.args[0].toLowerCase() == "up" || Deno.args[0].toLowerCase() == "down")
+
+if (Deno.args[0] && !isValidInput) {
+	console.log(`---\n>>> Arguments could not be parsed. Tool expects something like "wg-quick up vpn-name".\n---`)
+	Deno.exit(1);
+}
+
+await elevate();
+
+if (Deno.args[0]) {
+	const name = Deno.args[1]
+	const state = Deno.args[0].toLowerCase() == "up"
+	const config = (await getConfigByName(name))[0]
+
+	!config && console.log(`---\nArguments could not be parsed. Config (${name}) does not exist.\n---\n\n`)
+	config && config.status !== state && await toggleConfig(config)
+	config && Deno.exit(0)
+}
+
+while (true) {
+	const configs = await getConfigs()
+	printConfigs(configs)
+	console.log(`---`)
+	
+	const toggleInput = await promt(`Enter ID of config to toggle (1 .. ${configs.length}, q to quit): `);
+	if (toggleInput && parseInt(toggleInput) && parseInt(toggleInput) >= 1 && parseInt(toggleInput) <= configs.length) {
+		await toggleConfig(configs[parseInt(toggleInput) - 1])
+		await Sleep(1000)
+	} else if (toggleInput == "q") {
+		console.clear()
+		console.log("Have a nice day!")
+		await Sleep(1000)
+		break;
+	} else {
+		console.clear()
+		console.log("Error parsing input - please try again!")
+		await Sleep(2000)
+	}
+	console.clear()
+}


### PR DESCRIPTION
The first working version implements basic functionality known from [`wg-quick(8)`](https://git.zx2c4.com/wireguard-tools/about/src/man/wg-quick.8).
Those are `wg-quick [UP DOWN] [CONFIG-NAME]`.
There is currently no automatic installation process. One has to build the project according to [README.md](../blob/main/README.md) and add the executable to the users (or system) `$PATH` variable.